### PR TITLE
Propagate BlockVersion creation error up through the FFI, if a user t…

### DIFF
--- a/libmobilecoin/include/transaction.h
+++ b/libmobilecoin/include/transaction.h
@@ -179,13 +179,18 @@ MC_ATTRIBUTE_NONNULL(1, 2, 3);
 
 /* ==== McTransactionBuilder ==== */
 
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
 McTransactionBuilder* MC_NULLABLE mc_transaction_builder_create(
   uint64_t fee,
   uint64_t token_id,
   uint64_t tombstone_block,
   const McFogResolver* MC_NULLABLE fog_resolver,
   McTxOutMemoBuilder* MC_NONNULL memo_builder,
-  uint32_t block_version
+  uint32_t block_version,
+  McError* MC_NULLABLE * MC_NULLABLE out_error
 )
 MC_ATTRIBUTE_NONNULL(5);
 

--- a/libmobilecoin/include/transaction.h
+++ b/libmobilecoin/include/transaction.h
@@ -182,7 +182,8 @@ MC_ATTRIBUTE_NONNULL(1, 2, 3);
 ///
 /// # Errors
 ///
-/// * `LibMcError::InvalidInput`
+/// * `LibMcError::InvalidInput` - SDK consumers may wish to handle this error in
+///     part by checking if a software update is available
 McTransactionBuilder* MC_NULLABLE mc_transaction_builder_create(
   uint64_t fee,
   uint64_t token_id,

--- a/libmobilecoin/libmobilecoin_cbindgen.h
+++ b/libmobilecoin/libmobilecoin_cbindgen.h
@@ -760,12 +760,20 @@ bool mc_transaction_builder_ring_add_element(FfiMutPtr<McTransactionBuilderRing>
                                              FfiRefPtr<McBuffer> tx_out_proto_bytes,
                                              FfiRefPtr<McBuffer> membership_proof_proto_bytes);
 
+/**
+ *
+ * # Errors
+ *
+ * * `LibMcError::InvalidInput` - SDK consumers may wish to handle this error in
+ *     part by checking if a software update is available
+ */
 FfiOptOwnedPtr<McTransactionBuilder> mc_transaction_builder_create(uint64_t fee,
                                                                    uint64_t token_id,
                                                                    uint64_t tombstone_block,
                                                                    FfiOptRefPtr<McFogResolver> fog_resolver,
                                                                    FfiMutPtr<McTxOutMemoBuilder> memo_builder,
-                                                                   uint32_t block_version);
+                                                                   uint32_t block_version,
+                                                                   FfiOptMutPtr<FfiOptOwnedPtr<McError>> out_error);
 
 void mc_transaction_builder_free(FfiOptOwnedPtr<McTransactionBuilder> transaction_builder);
 

--- a/libmobilecoin/src/error.rs
+++ b/libmobilecoin/src/error.rs
@@ -10,7 +10,7 @@ use mc_crypto_keys::KeyError;
 use mc_crypto_noise::CipherError;
 use mc_fog_kex_rng::Error as FogKexRngError;
 use mc_fog_report_validation::{ingest_report::Error as IngestReportError, FogPubkeyError};
-use mc_transaction_core::AmountError;
+use mc_transaction_core::{AmountError, BlockVersionError};
 use mc_transaction_std::TxBuilderError;
 use mc_util_serial::DecodeError;
 use protobuf::ProtobufError;
@@ -120,6 +120,12 @@ impl From<KeyError> for LibMcError {
 
 impl From<ApiDisplayError> for LibMcError {
     fn from(err: ApiDisplayError) -> Self {
+        LibMcError::InvalidInput(format!("{:?}", err))
+    }
+}
+
+impl From<BlockVersionError> for LibMcError {
+    fn from(err: BlockVersionError) -> Self {
         LibMcError::InvalidInput(format!("{:?}", err))
     }
 }

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -370,6 +370,10 @@ pub extern "C" fn mc_transaction_builder_ring_add_element(
 pub type McTransactionBuilder = Option<TransactionBuilder<FogResolver>>;
 impl_into_ffi!(Option<TransactionBuilder<FogResolver>>);
 
+///
+/// # Errors
+///
+/// * `LibMcError::InvalidInput`
 #[no_mangle]
 pub extern "C" fn mc_transaction_builder_create(
     fee: u64,
@@ -378,8 +382,9 @@ pub extern "C" fn mc_transaction_builder_create(
     fog_resolver: FfiOptRefPtr<McFogResolver>,
     memo_builder: FfiMutPtr<McTxOutMemoBuilder>,
     block_version: u32,
+    out_error: FfiOptMutPtr<FfiOptOwnedPtr<McError>>,
 ) -> FfiOptOwnedPtr<McTransactionBuilder> {
-    ffi_boundary(|| {
+    ffi_boundary_with_error(out_error, || {
         let fog_resolver =
             fog_resolver
                 .as_ref()
@@ -390,7 +395,7 @@ pub extern "C" fn mc_transaction_builder_create(
                     FogResolver::new(fog_resolver.0.clone(), &fog_resolver.1)
                         .expect("FogResolver could not be constructed from the provided materials")
                 });
-        let block_version = BlockVersion::try_from(block_version).unwrap();
+        let block_version = BlockVersion::try_from(block_version)?;
 
         let memo_builder_box = memo_builder
             .into_mut()
@@ -408,7 +413,7 @@ pub extern "C" fn mc_transaction_builder_create(
         .expect("Could not create transaction builder");
 
         transaction_builder.set_tombstone_block(tombstone_block);
-        Some(transaction_builder)
+        Ok(Some(transaction_builder))
     })
 }
 

--- a/libmobilecoin/src/transaction.rs
+++ b/libmobilecoin/src/transaction.rs
@@ -373,7 +373,8 @@ impl_into_ffi!(Option<TransactionBuilder<FogResolver>>);
 ///
 /// # Errors
 ///
-/// * `LibMcError::InvalidInput`
+/// * `LibMcError::InvalidInput` - SDK consumers may wish to handle this error in
+///     part by checking if a software update is available
 #[no_mangle]
 pub extern "C" fn mc_transaction_builder_create(
     fee: u64,


### PR DESCRIPTION
> @carybakker rebased this change on-top of your branch, we will need it in master but makes sense to apply to the 1.2.x stuff you're cherry-picking

Previously, an "invalid" (too new)  BlockVersion would cause a rust panic due to the `.unwrap()` call in `mc_transaction_builder_create`. The correct way to deal with invalid BlockVersions is too propagate the error up through the FFI in the form of an `LibMcError:InvalidInput`

### Motivation

@garbageslam pointed out that the conditions for this panic could become common in the future and should be fixed asap. 

### Future Work
* Merge change into master but probably after we finish cherry picking 1.2.x changes.
